### PR TITLE
buffered auth biased for a single socket to keep post payload small.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Your authentication endpoint should be able to handle batched requests.
 
 ### Incoming post data
 
-    socket_id[0]	  00000.0000000
-    socket_id[1]	  00000.0000000
+    socket_id   	  00000.0000000
     channel_name[0]	  private-a
     channel_name[1]	  private-b
 

--- a/auth.php
+++ b/auth.php
@@ -2,8 +2,8 @@
 $config = require 'app_key.php';
 
 $response = [];
-foreach($_POST['socket_id'] as $i => $socketId){
-    $channel = $_POST['channel_name'][$i];
+$socketId = $_POST['socket_id'];
+foreach($_POST['channel_name'] as $i => $channel){
     $status = ($channel === 'private-d')? 403 : 200;
     if(!isset($response[$socketId])) $response[$socketId] = [];
     $response[$socketId][$channel] = [

--- a/lib/pusher-auth.js
+++ b/lib/pusher-auth.js
@@ -48,13 +48,11 @@
      *
      * @notice Override of original method signature by replacing socketId with requests argument
      */
-    BufferedAuthorizer.prototype.composeQuery = function(requests){
-        var i = 0, query = '';
-        for(var socketId in requests){
-            for(var channel in requests[socketId]){
-                query += '&socket_id[' + i + ']=' + encodeURIComponent(socketId) + '&channel_name[' + i + ']=' + encodeURIComponent(channel);
-                i++;
-            }
+    BufferedAuthorizer.prototype.composeQuery = function(socketInfo){
+        var i = 0, query = '&socket_id=' + encodeURIComponent(socketInfo.socketId);
+        for(var channel in socketInfo.channels){
+            query += '&channel_name[' + i + ']=' + encodeURIComponent(channel);
+            i++;
         }
         for(var param in this.authOptions.params) {
             query += '&' + encodeURIComponent(param) + '=' + encodeURIComponent(this.authOptions.params[param]);
@@ -63,31 +61,29 @@
     };
 
     /**
-     * Execute all queued auth requests
+     * Execute all queued auth requests for the first socketId
      */
     BufferedAuthorizer.prototype.executeRequests = function(){
-        var requests = this.requests;
-        this.requests = {};
-        Pusher.authorizers.ajax.call(this, requests, function(error, response){
+        // normal use-case involves a single socketId, so pop off. However, this allows to processing multiple socketIds if needed.
+        var socketId = Pusher.Util.keys(this.requests)[0];
+        var socketInfo = {socketId: socketId, channels: this.requests[socketId]};
+        delete this.requests[socketId];
+        Pusher.authorizers.ajax.call(this, socketInfo, function(error, response){
             if(error){
-                Pusher.Util.objectApply(requests, function(channels){
-                    Pusher.Util.objectApply(channels, function(callback){
-                        callback(true, response);
-                    });
+                Pusher.Util.objectApply(socketInfo.channels, function(callback){
+                    callback(true, response);
                 });
             }else{
-                Pusher.Util.objectApply(requests, function(channels, socketId){
-                    Pusher.Util.objectApply(channels, function(callback, channel){
-                        if(response[socketId] && response[socketId][channel]){
-                            if(!response[socketId][channel].status || response[socketId][channel].status === 200){
-                                callback(null, response[socketId][channel].data); // successful authentication
-                            }else{
-                                callback(true, response[socketId][channel].status); // authentication failed
-                            }
+                Pusher.Util.objectApply(socketInfo.channels, function(callback, channel){
+                    if(response[socketId] && response[socketId][channel]){
+                        if(!response[socketId][channel].status || response[socketId][channel].status === 200){
+                            callback(null, response[socketId][channel].data); // successful authentication
                         }else{
-                            callback(true, 404); // authentication data for this channel not returned
+                            callback(true, response[socketId][channel].status); // authentication failed
                         }
-                    });
+                    }else{
+                        callback(true, 404); // authentication data for this channel not returned
+                    }
                 });
             }
         });


### PR DESCRIPTION
Per #1, normal use-case involves a single socket_id, so batch by socket_id to keep POST payload trim.

Note: I guessed at the changes for auth.php.  Let me know if I missed something.
