### PR TITLE
Refactor the library to use the new Pusher extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ When subscribing to multiple private- and presence channels at once, your browse
 
 ## Prerequisites
 
-This is a plugin for the official [Pusher](http://pusher.com) JavaScript library and compatible with the latest 3.1.x release. Make sure you have a working implementation up and running.
+This is a plugin for the official [Pusher](http://pusher.com) JavaScript library and compatible with the latest 4.1.x release. Make sure you have a working implementation up and running.
 
-**Notice:** This version is not compatibile with Pusher 3.0 and older. Please use version [1.2.0](https://github.com/dirkbonhomme/pusher-js-auth/releases) of this plugin with older Pusher versions.
+**Notice:** This version is not compatible with Pusher 4.0 and older. Please use version [2.0.0](https://github.com/dirkbonhomme/pusher-js-auth/releases) of this plugin with older Pusher versions.
 
 Documentation and configuration options are explained at the [Pusher-js Github page](https://github.com/pusher/pusher-js)
 
@@ -15,7 +15,7 @@ Documentation and configuration options are explained at the [Pusher-js Github p
 
 Load the plugin after including the Pusher library
 
-    <script src="//js.pusher.com/3.0/pusher.min.js"></script>
+    <script src="//js.pusher.com/4.2/pusher.min.js"></script>
     <script src="lib/pusher-auth.js"></script>
 
 This plugin is also available on npm and bower:
@@ -28,13 +28,13 @@ This plugin is also available on npm and bower:
 This plugin comes with a few extra configuration parameters. The whole list is available at the [Pusher-js Github page](https://github.com/pusher/pusher-js#configuration)
 
     var pusher = new Pusher(API_KEY, {
-        authTransport: 'buffered',
+        authorizer: PusherBatchAuthorizer,
         authDelay: 200
     });
 
-### `authTransport` (String)
+### `authorizer` (Function)
 
-Required field. Use "buffered" to enable this plugin.
+Pass the function exposed by this plugin here. It is exposed as a module export when using AMD or CommonJS, and as the `PusherBatchAuthorizer` global otherwise.
 
 ### `authDelay` (Number)
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
 <body>
     <script src="app_key.js"></script>
     <script>if(!window.PUSHER_APP_KEY){ alert('Please create app_key.js with a valid Pusher key'); }</script>
-    <script src="http://js.pusher.com/3.1/pusher.min.js"></script>
+    <script src="https://js.pusher.com/4.2/pusher.min.js"></script>
     <script src="lib/pusher-auth.js"></script>
     <script>
 
         // Create pusher instance
         Pusher.log = window.console.log;
         var pusher = new Pusher(window.PUSHER_APP_KEY, {
-            authTransport: 'buffered',
+            authorizer: PusherBatchAuthorizer,
             authEndpoint: 'auth.php',
             authDelay: 200
         });

--- a/lib/pusher-auth.js
+++ b/lib/pusher-auth.js
@@ -4,7 +4,20 @@
  * Copyright 2016, Dirk Bonhomme <dirk@bytelogic.be>
  * Released under the MIT licence.
  */
-(function(Pusher){
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require('pusher-js'));
+  } else if (typeof define === 'function' && define.amd) {
+      // AMD. Register as an anonymous module.
+      define(['pusher-js'], factory);
+  } else {
+    // Browser globals (root is window)
+    root.PusherBatchAuthorizer = factory(root.Pusher);
+  }
+}(typeof self !== 'undefined' ? self : this, function(Pusher){
 
     /**
      * Utility method: loop over object's key and call method f with each member
@@ -133,24 +146,23 @@
      * Each endpoint and socket id gets its own buffered authorizer
      */
     var authorizers = {};
-    var buffered = function buffered(Runtime, socketId, callback){
-        var authEndpoint = this.options.authEndpoint;
-        var key = socketId + ':' + authEndpoint;
-        var authorizer = authorizers[key];
-        if(!authorizer){
-            authorizer = authorizers[key] = new BufferedAuthorizer({
-                socketId: socketId,
-                authEndpoint: authEndpoint,
-                authDelay: this.options.authDelay,
-                authOptions: this.options.auth
-            });
-        }
-        authorizer.add(this.channel.name, callback);
-    };
-    var supportedAuthorizers = Pusher.Runtime.getAuthorizers();
-    Pusher.Runtime.getAuthorizers = function(){
-        supportedAuthorizers.buffered = buffered;
-        return supportedAuthorizers;
-    };
 
-})(window.Pusher);
+    return function (channel, options) {
+        return {
+            authorize: function (socketId, callback) {
+                var authEndpoint = options.authEndpoint;
+                var key = socketId + ':' + authEndpoint;
+                var authorizer = authorizers[key];
+                if(!authorizer){
+                    authorizer = authorizers[key] = new BufferedAuthorizer({
+                        socketId: socketId,
+                        authEndpoint: authEndpoint,
+                        authDelay: options.authDelay,
+                        authOptions: options.auth
+                    });
+                }
+                authorizer.add(channel.name, callback);
+            }
+        }
+    }
+}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusher-js-auth",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Pusher plugin for batching auth requests in one HTTP call",
   "main": "lib/pusher-auth.js",


### PR DESCRIPTION
This exposes a function suited for the "authorizer" option of Pusher 4.1 instead of overriding internals to register as a auth transport.

The code exposing the function uses UMD, so it works for people using good-old global variables (creating `PusherBatchAuthorizer` but this can be changed if your prefer) but using module exports for people using CommonJS (webpack users for instance) or AMD (if anyone still does that, but support was only 2 lines).

There is still a single access to the Pusher runtime here (to create the XHR object), which could be replaced by `new XMLHttpRequest` if we want to avoid that access.

Closes #7