### PR TITLE
Remove unnecessary files from the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/dirkbonhomme/pusher-js-auth"
-  }
+  },
+  "files": [
+    "lib/"
+  ]
 }


### PR DESCRIPTION
The examples don't need to be shipped when installed the package as a dependency.