### PR TITLE
Add an optional peer dependency on pusher-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "client",
     "auth"
   ],
+  "peerDependencies": {
+    "pusher-js": "^4.1 || ^5 || ^6"
+  },
+  "peerDependenciesMeta": {
+    "pusher-js": {
+      "optional": true
+    }
+  },
   "author": "Dirk Bonhomme <dirk@bytelogic.be>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This has several benefits:

- it allows specifying the compatibility with pusher-js (version 7 is not supported in the current code for instance)
- it makes the code compatible with Yarn PnP mode and so with Yarn 2 (as a package cannot require parent dependencies in this mode due to not relying on hoisting)

The dependency is kept optional to account for projects using npm to perform the installation but loading pusher-js from a CDN and pusher-js-auth as a global-based script.