### PR TITLE
Upgrade to the new authorizer API for Pusher 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ When subscribing to multiple private- and presence channels at once, your browse
 
 ## Prerequisites
 
-This is a plugin for the official [Pusher](http://pusher.com) JavaScript library and compatible with the latest 4.1.x release. Make sure you have a working implementation up and running.
+This is a plugin for the official [Pusher](http://pusher.com) JavaScript library and compatible with the latest 7.0.x release. Make sure you have a working implementation up and running.
 
-**Notice:** This version is not compatible with Pusher 4.0 and older. Please use version [2.0.0](https://github.com/dirkbonhomme/pusher-js-auth/releases) of this plugin with older Pusher versions.
+**Notice:** This version is not compatible with Pusher 6.0 and older. Please use version [3.0](https://github.com/dirkbonhomme/pusher-js-auth/releases) of this plugin with older Pusher versions.
 
 Documentation and configuration options are explained at the [Pusher-js Github page](https://github.com/pusher/pusher-js)
 
@@ -38,7 +38,7 @@ Pass the function exposed by this plugin here. It is exposed as a module export 
 
 ### `authDelay` (Number)
 
-Optional, defaults to 0. Delay in milliseconds before executing an authentication request. The value can be as low as 0 when subcribing to multiple channels within the same event loop. Please note that the first authentication request is postponed anyway until the connection to Pusher succeeds.
+Optional, defaults to 0. Delay in milliseconds before executing an authentication request. The value can be as low as 0 when subscribing to multiple channels within the same event loop. Please note that the first authentication request is postponed anyway until the connection to Pusher succeeds.
 
 ## Server side authentication
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <body>
     <script src="app_key.js"></script>
     <script>if(!window.PUSHER_APP_KEY){ alert('Please create app_key.js with a valid Pusher key'); }</script>
-    <script src="https://js.pusher.com/4.2/pusher.min.js"></script>
+    <script src="https://js.pusher.com/7.0/pusher.min.js"></script>
     <script src="lib/pusher-auth.js"></script>
     <script>
 

--- a/lib/pusher-auth.js
+++ b/lib/pusher-auth.js
@@ -67,14 +67,14 @@
                         parsed = true;
                     }
                     catch (e) {
-                        callback(true, 'JSON returned from webapp was invalid, yet status code was 200. Data was: ' + xhr.responseText);
+                        callback(new Error('JSON returned from webapp was invalid, yet status code was 200. Data was: ' + xhr.responseText), { auth: '' });
                     }
                     if (parsed) {
-                        callback(false, data);
+                        callback(null, data);
                     }
                 }
                 else {
-                    callback(true, xhr.status);
+                    callback(new Error('Unable to retrieve auth string from auth endpoint - received status: ' + xhr.status), { auth: '' });
                 }
             }
         };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "client",
     "auth"
   ],
+  "peerDependencies": {
+    "pusher-js": "^4.1 || ^5 || ^6"
+  },
+  "peerDependenciesMeta": {
+    "pusher-js": {
+      "optional": true
+    }
+  },
   "author": "Dirk Bonhomme <dirk@bytelogic.be>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusher-js-auth",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "Pusher plugin for batching auth requests in one HTTP call",
   "main": "lib/pusher-auth.js",
@@ -10,7 +10,7 @@
     "auth"
   ],
   "peerDependencies": {
-    "pusher-js": "^4.1 || ^5 || ^6"
+    "pusher-js": "^7"
   },
   "peerDependenciesMeta": {
     "pusher-js": {


### PR DESCRIPTION
Pusher 7 changed the signature of the callback it passes to custom authorizers, to match the standard error callback convention from node.

For now, this PR is built on top of #14 to include the update of the peer dependency.