### PR TITLE
Fix formatting of the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,35 @@
 
 ## 4.0.0 (2020-09-11)
 
-[UPDATE] Refactored plugin for compatibility with Pusher client 7.x (kudos @stof)
-[UPDATE] Remove unnecessary files from the npm package
-[UPDATE] Add an optional peer dependency on pusher-js
+- [UPDATE] Refactored plugin for compatibility with Pusher client 7.x (kudos @stof)
+- [UPDATE] Remove unnecessary files from the npm package
+- [UPDATE] Add an optional peer dependency on pusher-js
 
 ## 3.0.1 (2018-06-15)
 
-[UPDATE] Allow `auth` options to be a function instead of a static object
+- [UPDATE] Allow `auth` options to be a function instead of a static object
 
 ## 3.0.0 (2018-01-15)
 
-[UPDATE] Refactored plugin for compatibility with Pusher client 3.1.x (kudos @stof)
+- [UPDATE] Refactored plugin for compatibility with Pusher client 3.1.x (kudos @stof)
 
 ## 2.0.0 (2016-05-17)
 
-[UPDATE] Refactored plugin for compatibility with Pusher client 3.1.x
+- [UPDATE] Refactored plugin for compatibility with Pusher client 3.1.x
 
 ## 1.2.0 (2015-02-16)
 
-[UPDATE] Published to npmjs and bower (kudos @dincho)
-[UPDATE] Updating docs and examples to highlight compatibility with Pusher 3.x
+- [UPDATE] Published to npmjs and bower (kudos @dincho)
+- [UPDATE] Updating docs and examples to highlight compatibility with Pusher 3.x
 
 ## 1.1.0 (2014-08-09)
 
-[UPDATE] Authorizers deal with a single socket id and simplify auth endpoint
+- [UPDATE] Authorizers deal with a single socket id and simplify auth endpoint
 
 ## 1.0.1 (2014-08-07)
 
-[UPDATE] Simplify code by using Pusher's internal ajax call (@marknadig)
+- [UPDATE] Simplify code by using Pusher's internal ajax call (@marknadig)
 
 ## 1.0.0 (2014-07-25)
 
-[NEW] Implemented buffered authorizer
+- [NEW] Implemented buffered authorizer


### PR DESCRIPTION
This now uses a list, which ensures that each entry stays on a separate line