### PR TITLE
Add type definitions for the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 !.gitignore
+/node_modules
+/package-lock.json
 
 app_key.js
 app_key.php

--- a/lib/pusher-auth.d.ts
+++ b/lib/pusher-auth.d.ts
@@ -1,0 +1,13 @@
+import { AuthorizerGenerator } from 'pusher-js';
+
+export as namespace PusherBatchAuthorizer;
+
+declare const pusherBatchAuthorizer: AuthorizerGenerator;
+
+export = pusherBatchAuthorizer;
+
+declare module 'pusher-js' {
+    export interface AuthorizerOptions {
+        authDelay?: number;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Pusher plugin for batching auth requests in one HTTP call",
   "main": "lib/pusher-auth.js",
+  "types": "lib/pusher-auth.d.ts",
   "keywords": [
     "pusher",
     "client",
@@ -16,6 +17,9 @@
     "pusher-js": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "pusher-js": "^7"
   },
   "author": "Dirk Bonhomme <dirk@bytelogic.be>",
   "contributors": [


### PR DESCRIPTION
This adds type definitions in the library, making it easier to use this library in typescript.

Most of the typing is actually done by pusher-js itself. I simply document the fact that the exported function implements the `AuthorizerGenerator` type of pusher-js.
However, I also extend the `AuthorizerOptions` type to document the `authDelay` option that is being added by that authorizer.