### PR TITLE
adapt the library to work on a service worker

### DIFF
--- a/lib/pusher-auth.js
+++ b/lib/pusher-auth.js
@@ -9,10 +9,10 @@
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.
-    module.exports = factory(require('pusher-js'));
+    module.exports = factory(require('pusher-js/worker'));
   } else if (typeof define === 'function' && define.amd) {
       // AMD. Register as an anonymous module.
-      define(['pusher-js'], factory);
+      define(['pusher-js/worker'], factory);
   } else {
     // Browser globals (root is window)
     root.PusherBatchAuthorizer = factory(root.Pusher);
@@ -78,8 +78,32 @@
                 }
             }
         };
-        xhr.send(composeQuery(requests, socketId, authOptions));
+      	xhr.send(composeQuery(requests, socketId, authOptions));
     }
+
+    /**
+    * Execute fetch request to auth endpoint (This is added to handle service workers)
+    */
+      function fetchRequest (requests, socketId, authOptions, authEndpoint, callback) {
+        var myHeaders = new Headers();
+        myHeaders.append("Authorization", authOptions.headers.Authorization);
+        var formdata = new FormData();
+        formdata.append("socket_id", socketId);
+        Object.keys(requests).forEach((channel, index) => {
+          formdata.append(`channel_name[${index}]`, channel);
+        });
+        var requestOptions = {
+          method: 'POST',
+          headers: myHeaders,
+          body: formdata,
+          redirect: 'follow'
+        };
+
+        return fetch(authEndpoint, requestOptions)
+          .then(response =>  response.text())
+          .then(result => callback(null, result))
+          .catch(error => callback(new Error('JSON returned from webapp was invalid, yet status code was 200. Data was: ' + error), { auth: '' }));
+      }
 
     /**
      * Buffered authorizer constructor
@@ -122,25 +146,28 @@
     BufferedAuthorizer.prototype.executeRequests = function(){
         var requests = this.requests;
         this.requests = {};
-        xhrRequest(requests, this.options.socketId, this.authOptions, this.options.authEndpoint, function(error, response){
-            if(error){
-                objectApply(requests, function(callback){
-                    callback(true, response);
-                });
-            }else{
-                objectApply(requests, function(callback, channel){
-                    if(response[channel]){
-                        if(!response[channel].status || response[channel].status === 200){
-                            callback(null, response[channel].data); // successful authentication
-                        }else{
-                            callback(true, response[channel].status); // authentication failed
-                        }
-                    }else{
-                        callback(true, 404); // authentication data for this channel not returned
-                    }
-                });
-            }
-        });
+        const fetchCall = (error, response) => {
+          if(error){
+            objectApply(requests, function(callback){
+              callback(true, response);
+            });
+          }else{
+            objectApply(requests, function(callback, channel){
+              const responseJson = JSON.parse(response)
+                if(responseJson[channel]){
+                  if(!responseJson[channel].status || responseJson[channel].status === 200){
+                    callback(null, responseJson[channel].data); // successful authentication
+                  }else{
+                    callback(true, responseJson[channel].status); // authentication failed
+                  }
+                }else{
+                    callback(true, 404); // authentication data for this channel not returned
+                }
+              });
+          }
+        }
+
+        fetchRequest(requests, this.options.socketId, this.authOptions, this.options.authEndpoint, fetchCall);
     };
 
     /**


### PR DESCRIPTION
To use Pusher Auth inside a Chrome extension in manifest v3 needs forcefully use fetch and not XHR
https://developer.chrome.com/docs/extensions/mv3/mv3-migration/#background-service-workers

- change the path from pusher-js to pusher-js/worker
- add the function fetch request to make the request instead of the XHR request
- implement fetch request instead in BufferedAuthorizer.prototype.executeRequests